### PR TITLE
Add check for reversed boolean

### DIFF
--- a/src/Resources/views/html5-blocks.html.twig
+++ b/src/Resources/views/html5-blocks.html.twig
@@ -1,8 +1,9 @@
 {% set collection = (collection is defined) ? collection : 'blocks' %}
 {% set element = (element is defined) ? element : 'main' %}
+{% set blocks = (blocks is defined) ? blocks : content[collection] %}
 
 <{{ element }} property='{{ collection }}' typeof='collection'>
-{% for index,block in content[collection] %}
+{% for index,block in blocks %}
     {% include '@ConnectHollandSuluBlock/html5/'~block.type~'.html.twig'
         with {
             block: block,


### PR DESCRIPTION
This adds the option to show blocks in reversed order. At the moment when, for example, a link to a news article is added it will show last in the overview of the links.
This PR makes it possible to add a reversedorder boolean in the template. When the boolean exists and is set to true, the link will be shown first in the overview.