### PR TITLE
Allow to use a different property name for images

### DIFF
--- a/src/Resources/views/html5/parts/images.html.twig
+++ b/src/Resources/views/html5/parts/images.html.twig
@@ -2,7 +2,7 @@
 {% set images = (images is defined) ? images : block[block_property] %}
 
 {%- block images -%}
-<div class='{{ block_property }} {{ blockview[block_property].displayOption }}' property='{{ block_property }}'>
+<div class='images{% if block_property != 'images' %} {{ block_property }}{% endif %} {{ blockview[block_property].displayOption }}' property='{{ block_property }}'>
     {% set resolved_images = sulu_resolve_medias(images, app.request.locale) %}
     {% for image in resolved_images %}
         {%- block image -%}

--- a/src/Resources/views/html5/parts/images.html.twig
+++ b/src/Resources/views/html5/parts/images.html.twig
@@ -1,8 +1,10 @@
-{% set images = (images is defined) ? images : block.images %}
+{% set block_property = (block_property is defined) ? block_property : 'images' %}
+{% set images = (images is defined) ? images : block[block_property] %}
+
 {%- block images -%}
-<div class='images {{ blockview.images.displayOption }}' property='images'>
-    {% set images = sulu_resolve_medias(images, app.request.locale) %}
-    {% for image in images %}
+<div class='{{ block_property }} {{ blockview[block_property].displayOption }}' property='{{ block_property }}'>
+    {% set resolved_images = sulu_resolve_medias(images, app.request.locale) %}
+    {% for image in resolved_images %}
         {%- block image -%}
         <img
             {% block image_attributes %}


### PR DESCRIPTION
This will allow to use the block as

```twig
{% include '@ConnectHollandSuluBlock/html5/parts/images.html.twig' with {block_property: 'myOwnProperty'} %}
```