### PR TITLE
Small change to work with symfony 5

### DIFF
--- a/src/ConnectHollandSuluBlockBundle.php
+++ b/src/ConnectHollandSuluBlockBundle.php
@@ -14,7 +14,7 @@ class ConnectHollandSuluBlockBundle extends Bundle
      */
     public function build(ContainerBuilder $container)
     {
-        $rootDirectory = $container->getParameter('kernel.root_dir');
+        $rootDirectory = $container->getParameter('kernel.project_dir');
         $this->registerStream($rootDirectory);
     }
 
@@ -23,7 +23,7 @@ class ConnectHollandSuluBlockBundle extends Bundle
      */
     public function boot()
     {
-        $rootDirectory = $this->container->get('kernel')->getRootDir();
+        $rootDirectory = $this->container->get('kernel')->getProjectDir();
         $this->registerStream($rootDirectory);
         $this->container->get('twig')->getLoader()->addPath($this->getPath().'/Resources/views', 'sulu-block-bundle');
 


### PR DESCRIPTION
Change `root` namespace to `project` to have the bundle working with symfony 5